### PR TITLE
Create model using the settings in the repositories.php config file. …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,4 @@
 /vendor
 composer.phar
 composer.lock
-.idea/dugajeanRepository.iml
-.idea/misc.xml
-.idea/modules.xml
-.idea/php-inspections-ea-ultimate.xml
-.idea/php.xml
-.idea/vcs.xml
-.idea/workspace.xml
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 /vendor
 composer.phar
 composer.lock
+.idea/dugajeanRepository.iml
+.idea/misc.xml
+.idea/modules.xml
+.idea/php-inspections-ea-ultimate.xml
+.idea/php.xml
+.idea/vcs.xml
+.idea/workspace.xml

--- a/README.md
+++ b/README.md
@@ -29,6 +29,32 @@ Where `Film` is the name of an existing model. If the model does not exist, it w
 
 Finally, use the repository in the controller:
 
+```php
+<?php 
+
+namespace App\Http\Controllers;
+
+use App\Repositories\FilmRepository;
+
+class FilmsController extends Controller {
+
+    /**
+     * @var FilmRepository 
+     */
+    private $filmRepository;
+
+    public function __construct(FilmRepository $filmRepository) 
+    {
+        $this->filmRepository = $filmRepository;
+    }
+
+    public function index() 
+    {
+        return response()->json($this->filmRepository->all());
+    }
+}
+```
+
 ## Config
 
 Add custom directory for your models, and model path like this :
@@ -64,32 +90,6 @@ Then create a repository like this :
 This will create a Repository file within `app/Repositories`, and 
 a model file within `app/Models`
 
-
-```php
-<?php 
-
-namespace App\Http\Controllers;
-
-use App\Repositories\FilmRepository;
-
-class FilmsController extends Controller {
-
-    /**
-     * @var FilmRepository 
-     */
-    private $filmRepository;
-
-    public function __construct(FilmRepository $filmRepository) 
-    {
-        $this->filmRepository = $filmRepository;
-    }
-
-    public function index() 
-    {
-        return response()->json($this->filmRepository->all());
-    }
-}
-```
 
 ###### Publishing The Configuration
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add custom directory for your models, and model path like this :
         | The model namespace.
         |
         */
-        'model_namespace' => 'App\Entities',
+        'model_namespace' => 'App\Models',
     
         /*
         |--------------------------------------------------------------------------
@@ -53,7 +53,7 @@ Add custom directory for your models, and model path like this :
         |
         */
     
-        'model_path' => 'app' . DIRECTORY_SEPARATOR . 'Entities'
+        'model_path' => 'app' . DIRECTORY_SEPARATOR . 'Models'
 ```
 
 Then create a repository like this : 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,42 @@ Where `Film` is the name of an existing model. If the model does not exist, it w
 
 Finally, use the repository in the controller:
 
+## Config
+
+Add custom directory for your models, and model path like this :
+
+```php
+    /*
+        |--------------------------------------------------------------------------
+        | Model namespace
+        |--------------------------------------------------------------------------
+        |
+        | The model namespace.
+        |
+        */
+        'model_namespace' => 'App\Entities',
+    
+        /*
+        |--------------------------------------------------------------------------
+        | Model Path
+        |--------------------------------------------------------------------------
+        |
+        | The model path.
+        |
+        */
+    
+        'model_path' => 'app' . DIRECTORY_SEPARATOR . 'Entities'
+```
+
+Then create a repository like this : 
+
+```php
+    php artisan make:repository Test
+```
+This will create a Repository file within `app/Repositories`, and 
+a model file within `app/Entities`
+
+
 ```php
 <?php 
 
@@ -142,6 +178,7 @@ $this->filmRepository->findWhere([
     ['year', '>', $year]
 ]);
 ```
+
 
 ## Criteria
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Then create a repository like this :
     php artisan make:repository Test
 ```
 This will create a Repository file within `app/Repositories`, and 
-a model file within `app/Entities`
+a model file within `app/Models`
 
 
 ```php

--- a/config/repositories.php
+++ b/config/repositories.php
@@ -50,7 +50,7 @@
         | The model namespace.
         |
         */
-        'model_namespace' => 'App\Entities',
+        'model_namespace' => 'App\Models',
 
         /*
         |--------------------------------------------------------------------------
@@ -61,5 +61,5 @@
         |
         */
 
-        'model_path' => 'app' . DIRECTORY_SEPARATOR . 'Entities'
+        'model_path' => 'app' . DIRECTORY_SEPARATOR . 'Models'
     ];

--- a/config/repositories.php
+++ b/config/repositories.php
@@ -1,54 +1,65 @@
 <?php
 
-return [
+    return [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Repository namespace
-    |--------------------------------------------------------------------------
-    |
-    | The namespace for the repository classes.
-    |
-    */
-    'repository_namespace' => 'App\Repositories',
+        /*
+        |--------------------------------------------------------------------------
+        | Repository namespace
+        |--------------------------------------------------------------------------
+        |
+        | The namespace for the repository classes.
+        |
+        */
+        'repository_namespace' => 'App\Repositories',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Repository path
-    |--------------------------------------------------------------------------
-    |
-    | The path to the repository folder.
-    |
-    */
-    'repository_path' => 'app' . DIRECTORY_SEPARATOR . 'Repositories',
+        /*
+        |--------------------------------------------------------------------------
+        | Repository path
+        |--------------------------------------------------------------------------
+        |
+        | The path to the repository folder.
+        |
+        */
+        'repository_path' => 'app' . DIRECTORY_SEPARATOR . 'Repositories',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Criteria namespace
-    |--------------------------------------------------------------------------
-    |
-    | The namespace for the criteria classes.
-    |
-    */
-    'criteria_namespace' => 'App\Repositories\Criteria',
+        /*
+        |--------------------------------------------------------------------------
+        | Criteria namespace
+        |--------------------------------------------------------------------------
+        |
+        | The namespace for the criteria classes.
+        |
+        */
+        'criteria_namespace' => 'App\Repositories\Criteria',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Criteria path
-    |--------------------------------------------------------------------------
-    |
-    | The path to the criteria folder.
-    |
-    */
-    'criteria_path' => 'app' . DIRECTORY_SEPARATOR . 'Repositories' . DIRECTORY_SEPARATOR . 'Criteria',
+        /*
+        |--------------------------------------------------------------------------
+        | Criteria path
+        |--------------------------------------------------------------------------
+        |
+        | The path to the criteria folder.
+        |
+        */
+        'criteria_path' => 'app' . DIRECTORY_SEPARATOR . 'Repositories' . DIRECTORY_SEPARATOR . 'Criteria',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Model namespace
-    |--------------------------------------------------------------------------
-    |
-    | The model namespace.
-    |
-    */
-    'model_namespace' => 'App',
-];
+        /*
+        |--------------------------------------------------------------------------
+        | Model namespace
+        |--------------------------------------------------------------------------
+        |
+        | The model namespace.
+        |
+        */
+        'model_namespace' => 'App\Entities',
+
+        /*
+        |--------------------------------------------------------------------------
+        | Model Path
+        |--------------------------------------------------------------------------
+        |
+        | The model path.
+        |
+        */
+
+        'model_path' => 'app' . DIRECTORY_SEPARATOR . 'Entities'
+    ];

--- a/resources/stubs/repository.stub
+++ b/resources/stubs/repository.stub
@@ -2,7 +2,7 @@
 
 namespace repository_namespace;
 
-use model_path\model_name;
+use model_namespace\model_name;
 use Dugajean\Repositories\Eloquent\Repository;
 
 class repository_class extends Repository

--- a/src/Console/Commands/Creators/RepositoryCreator.php
+++ b/src/Console/Commands/Creators/RepositoryCreator.php
@@ -1,251 +1,97 @@
 <?php
 
-    namespace Dugajean\Repositories\Console\Commands\Creators;
+namespace Dugajean\Repositories\Console\Commands\Creators;
 
-    use Illuminate\Filesystem\Filesystem;
-    use Illuminate\Support\Facades\Config;
-    use Illuminate\Support\Facades\Artisan;
-    use Illuminate\Database\Eloquent\Model;
-    use Doctrine\Common\Inflector\Inflector;
-    use Dugajean\Repositories\Eloquent\Repository;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Artisan;
+use Doctrine\Common\Inflector\Inflector;
 
-    class RepositoryCreator
+class RepositoryCreator extends BaseCreator
+{
+    /**
+     * Get the repository name.
+     *
+     * @return mixed|string
+     */
+    public function getName()
     {
-        /**
-         * @var Filesystem
-         */
-        protected $files;
+        $repositoryName = parent::getName();
 
-        /**
-         * @var Repository
-         */
-        protected $repository;
-
-        /**
-         * @var Model
-         */
-        protected $model;
-
-        /**
-         * @param Filesystem $files
-         */
-        public function __construct(Filesystem $files)
-        {
-            $this->files = $files;
+        if (strpos($repositoryName, 'Repository') === false) {
+            $repositoryName .= 'Repository';
         }
 
-        /**
-         * @return mixed
-         */
-        public function getRepository()
-        {
-            return $this->repository;
-        }
-
-        /**
-         * @param mixed $repository
-         */
-        public function setRepository($repository)
-        {
-            $this->repository = $repository;
-        }
-
-        /**
-         * @return Model
-         */
-        public function getModel()
-        {
-            return $this->model;
-        }
-
-        /**
-         * @param Model $model
-         */
-        public function setModel($model)
-        {
-            $this->model = $model;
-        }
-
-        /**
-         * Create the repository.
-         *
-         * @param Repository $repository
-         * @param Model      $model
-         *
-         * @return int
-         * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
-         */
-        public function create($repository, $model)
-        {
-            $this->setRepository($repository);
-            $this->setModel($model);
-            $this->createDirectory();
-
-            return $this->createClass();
-        }
-
-        /**
-         * Create the necessary directory.
-         */
-        protected function createDirectory()
-        {
-            $directory = $this->getDirectory();
-
-            if (!$this->files->isDirectory($directory)) {
-                $this->files->makeDirectory($directory, 0755, true);
-            }
-        }
-
-        /**
-         * Get the repository directory.
-         *
-         * @return mixed
-         */
-        protected function getDirectory()
-        {
-            return Config::get('repositories.repository_path');
-        }
-
-        /**
-         * Get the repository name.
-         *
-         * @return mixed|string
-         */
-        protected function getRepositoryName()
-        {
-            $repositoryName = $this->getRepository();
-
-            if (!strpos($repositoryName, 'Repository') !== false) {
-                $repositoryName .= 'Repository';
-            }
-
-            // Return repository name.
-            return $repositoryName;
-        }
-
-        /**
-         * Get the model name.
-         *
-         * @return string
-         */
-        protected function getModelName()
-        {
-            $model = $this->getModel();
-
-            if (isset($model) && !empty($model)) {
-                $modelName = $model;
-            } else {
-                $modelName = Inflector::singularize($this->stripRepositoryName());
-            }
-
-            return $modelName;
-        }
-
-        /**
-         * Get the stripped repository name.
-         *
-         * @return string
-         */
-        protected function stripRepositoryName()
-        {
-            $repository = strtolower($this->getRepository());
-            $stripped = str_replace("repository", "", $repository);
-            $result = ucfirst($stripped);
-
-            return $result;
-        }
-
-        /**
-         * Get the populate data.
-         *
-         * @return array
-         */
-        protected function getPopulateData()
-        {
-            $repositoryNamespace = Config::get('repositories.repository_namespace');
-            $repositoryClass = $this->getRepositoryName();
-            $modelPath = Config::get('repositories.model_path');
-            $modelName = $this->getModelName();
-            $modelNamespace = Config::get('repositories.model_namespace');
-
-            $populateData = [
-                'repository_namespace' => $repositoryNamespace,
-                'repository_class' => $repositoryClass,
-                'model_path' => $modelPath,
-                'model_namespace' => $modelNamespace,
-                'model_name' => $modelName,
-            ];
-
-            return $populateData;
-        }
-
-        /**
-         * Get the path.
-         *
-         * @return string
-         */
-        protected function getPath()
-        {
-            return $this->getDirectory() . DIRECTORY_SEPARATOR . $this->getRepositoryName() . '.php';
-        }
-
-        /**
-         * Get the stub.
-         *
-         * @return string
-         * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
-         */
-        protected function getStub()
-        {
-            return $this->files->get($this->getStubPath() . "repository.stub");
-        }
-
-        /**
-         * Get the stub path.
-         *
-         * @return string
-         */
-        protected function getStubPath()
-        {
-            return __DIR__ . '/../../../../resources/stubs/';
-        }
-
-        /**
-         * Populate the stub.
-         *
-         * @return mixed
-         * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
-         */
-        protected function populateStub()
-        {
-            $populate_data = $this->getPopulateData();
-            $stub = $this->getStub();
-
-            foreach ($populate_data as $key => $value) {
-                $stub = str_replace($key, $value, $stub);
-            }
-
-            return $stub;
-        }
-
-        /**
-         * Creates the class.
-         *
-         * @return bool|int
-         * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
-         */
-        protected function createClass()
-        {
-            $model = explode('\\', Config::get('repositories.model_namespace'))[1] . '\\' . $this->repository;
-
-            if (!class_exists($model)) {
-                Artisan::call('make:model', ['name' => $model]);
-            }
-
-            if ($this->files->exists($this->getPath())) {
-                throw new \RuntimeException("The repository with the name '$this->repository' already exists.");
-            }
-
-            return $this->files->put($this->getPath(), $this->populateStub());
-        }
+        // Return repository name.
+        return $repositoryName;
     }
+
+    /**
+     * Get the populate data.
+     *
+     * @return array
+     */
+    protected function getPopulateData()
+    {
+        $repositoryNamespace = Config::get('repositories.repository_namespace');
+        $repositoryClass = $this->getRepositoryName();
+        $modelPath = Config::get('repositories.model_path');
+        $modelName = $this->getModelName();
+        $modelNamespace = Config::get('repositories.model_namespace');
+
+        $populateData = [
+            'repository_namespace' => $repositoryNamespace,
+            'repository_class' => $repositoryClass,
+            'model_path' => $modelPath,
+            'model_namespace' => $modelNamespace,
+            'model_name' => $modelName,
+        ];
+
+        return $populateData;
+    }
+
+    /**
+     * Creates the class.
+     *
+     * @return bool|int
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    protected function createClass()
+    {
+        $model = explode('\\', Config::get('repositories.model_namespace'))[1] . '\\' . $this->name;
+
+        if (!class_exists($model)) {
+            Artisan::call('make:model', ['name' => $model]);
+        }
+
+        if ($this->files->exists($this->getPath())) {
+            throw new \RuntimeException("The repository with the name '{$this->getName()}' already exists.");
+        }
+
+        return $this->files->put($this->getPath(), $this->populateStub());
+    }
+
+    /**
+     * Get the model name.
+     *
+     * @return string
+     */
+    private function getModelName()
+    {
+        $model = $this->getModel();
+
+        return isset($model) && !empty($model) ? $model : Inflector::singularize($this->stripRepositoryName());
+    }
+
+    /**
+     * Get the stripped repository name.
+     *
+     * @return string
+     */
+    private function stripRepositoryName()
+    {
+        $stripped = str_ireplace('repository', '', $this->getName());
+        $result = ucfirst($stripped);
+
+        return $result;
+    }
+}

--- a/src/Console/Commands/Creators/RepositoryCreator.php
+++ b/src/Console/Commands/Creators/RepositoryCreator.php
@@ -1,99 +1,251 @@
 <?php
 
-namespace Dugajean\Repositories\Console\Commands\Creators;
+    namespace Dugajean\Repositories\Console\Commands\Creators;
 
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Artisan;
-use Doctrine\Common\Inflector\Inflector;
+    use Illuminate\Filesystem\Filesystem;
+    use Illuminate\Support\Facades\Config;
+    use Illuminate\Support\Facades\Artisan;
+    use Illuminate\Database\Eloquent\Model;
+    use Doctrine\Common\Inflector\Inflector;
+    use Dugajean\Repositories\Eloquent\Repository;
 
-class RepositoryCreator extends BaseCreator
-{
-    /**
-     * Get the repository name.
-     *
-     * @return mixed|string
-     */
-    public function getName()
+    class RepositoryCreator
     {
-        $repositoryName = parent::getName();
+        /**
+         * @var Filesystem
+         */
+        protected $files;
 
-        if (strpos($repositoryName, 'Repository') === false) {
-            $repositoryName .= 'Repository';
+        /**
+         * @var Repository
+         */
+        protected $repository;
+
+        /**
+         * @var Model
+         */
+        protected $model;
+
+        /**
+         * @param Filesystem $files
+         */
+        public function __construct(Filesystem $files)
+        {
+            $this->files = $files;
         }
 
-        // Return repository name.
-        return $repositoryName;
-    }
+        /**
+         * @return mixed
+         */
+        public function getRepository()
+        {
+            return $this->repository;
+        }
 
-    /**
-     * Get the populate data.
-     *
-     * @return array
-     */
-    protected function getPopulateData()
-    {
-        $repositoryNamespace = Config::get('repositories.repository_namespace');
-        $repositoryClass = $this->getName();
-        $modelPath = Config::get('repositories.model_namespace');
-        $modelName = $this->getModelName();
+        /**
+         * @param mixed $repository
+         */
+        public function setRepository($repository)
+        {
+            $this->repository = $repository;
+        }
 
-        $populateData = [
-            'repository_namespace' => $repositoryNamespace,
-            'repository_class' => $repositoryClass,
-            'model_path' => $modelPath,
-            'model_name' => $modelName,
-        ];
+        /**
+         * @return Model
+         */
+        public function getModel()
+        {
+            return $this->model;
+        }
 
-        return $populateData;
-    }
+        /**
+         * @param Model $model
+         */
+        public function setModel($model)
+        {
+            $this->model = $model;
+        }
 
-    /**
-     * Creates the class.
-     *
-     * @return bool|int
-     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
-     */
-    protected function createClass()
-    {
-        $model = Config::get('repositories.model_namespace') . '\\' . $this->name;
+        /**
+         * Create the repository.
+         *
+         * @param Repository $repository
+         * @param Model      $model
+         *
+         * @return int
+         * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+         */
+        public function create($repository, $model)
+        {
+            $this->setRepository($repository);
+            $this->setModel($model);
+            $this->createDirectory();
 
-        if (!class_exists($model)) {
-            if ($this->command->confirm("Do you want to create a {$model} model?")) {
-                Artisan::call('make:model', ['name' => $this->name]);
-            } else {
-                throw new \RuntimeException("Could not create repository: Model {$model} does not exist.");
+            return $this->createClass();
+        }
+
+        /**
+         * Create the necessary directory.
+         */
+        protected function createDirectory()
+        {
+            $directory = $this->getDirectory();
+
+            if (!$this->files->isDirectory($directory)) {
+                $this->files->makeDirectory($directory, 0755, true);
             }
         }
 
-        if ($this->files->exists($this->getPath())) {
-            throw new \RuntimeException("The repository with the name '{$this->getName()}' already exists.");
+        /**
+         * Get the repository directory.
+         *
+         * @return mixed
+         */
+        protected function getDirectory()
+        {
+            return Config::get('repositories.repository_path');
         }
 
-        return $this->files->put($this->getPath(), $this->populateStub());
+        /**
+         * Get the repository name.
+         *
+         * @return mixed|string
+         */
+        protected function getRepositoryName()
+        {
+            $repositoryName = $this->getRepository();
+
+            if (!strpos($repositoryName, 'Repository') !== false) {
+                $repositoryName .= 'Repository';
+            }
+
+            // Return repository name.
+            return $repositoryName;
+        }
+
+        /**
+         * Get the model name.
+         *
+         * @return string
+         */
+        protected function getModelName()
+        {
+            $model = $this->getModel();
+
+            if (isset($model) && !empty($model)) {
+                $modelName = $model;
+            } else {
+                $modelName = Inflector::singularize($this->stripRepositoryName());
+            }
+
+            return $modelName;
+        }
+
+        /**
+         * Get the stripped repository name.
+         *
+         * @return string
+         */
+        protected function stripRepositoryName()
+        {
+            $repository = strtolower($this->getRepository());
+            $stripped = str_replace("repository", "", $repository);
+            $result = ucfirst($stripped);
+
+            return $result;
+        }
+
+        /**
+         * Get the populate data.
+         *
+         * @return array
+         */
+        protected function getPopulateData()
+        {
+            $repositoryNamespace = Config::get('repositories.repository_namespace');
+            $repositoryClass = $this->getRepositoryName();
+            $modelPath = Config::get('repositories.model_path');
+            $modelName = $this->getModelName();
+            $modelNamespace = Config::get('repositories.model_namespace');
+
+            $populateData = [
+                'repository_namespace' => $repositoryNamespace,
+                'repository_class' => $repositoryClass,
+                'model_path' => $modelPath,
+                'model_namespace' => $modelNamespace,
+                'model_name' => $modelName,
+            ];
+
+            return $populateData;
+        }
+
+        /**
+         * Get the path.
+         *
+         * @return string
+         */
+        protected function getPath()
+        {
+            return $this->getDirectory() . DIRECTORY_SEPARATOR . $this->getRepositoryName() . '.php';
+        }
+
+        /**
+         * Get the stub.
+         *
+         * @return string
+         * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+         */
+        protected function getStub()
+        {
+            return $this->files->get($this->getStubPath() . "repository.stub");
+        }
+
+        /**
+         * Get the stub path.
+         *
+         * @return string
+         */
+        protected function getStubPath()
+        {
+            return __DIR__ . '/../../../../resources/stubs/';
+        }
+
+        /**
+         * Populate the stub.
+         *
+         * @return mixed
+         * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+         */
+        protected function populateStub()
+        {
+            $populate_data = $this->getPopulateData();
+            $stub = $this->getStub();
+
+            foreach ($populate_data as $key => $value) {
+                $stub = str_replace($key, $value, $stub);
+            }
+
+            return $stub;
+        }
+
+        /**
+         * Creates the class.
+         *
+         * @return bool|int
+         * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+         */
+        protected function createClass()
+        {
+            $model = explode('\\', Config::get('repositories.model_namespace'))[1] . '\\' . $this->repository;
+
+            if (!class_exists($model)) {
+                Artisan::call('make:model', ['name' => $model]);
+            }
+
+            if ($this->files->exists($this->getPath())) {
+                throw new \RuntimeException("The repository with the name '$this->repository' already exists.");
+            }
+
+            return $this->files->put($this->getPath(), $this->populateStub());
+        }
     }
-
-    /**
-     * Get the model name.
-     *
-     * @return string
-     */
-    private function getModelName()
-    {
-        $model = $this->getModel();
-
-        return isset($model) && !empty($model) ? $model : Inflector::singularize($this->stripRepositoryName());
-    }
-
-    /**
-     * Get the stripped repository name.
-     *
-     * @return string
-     */
-    private function stripRepositoryName()
-    {
-        $stripped = str_ireplace('repository', '', $this->getName());
-        $result = ucfirst($stripped);
-
-        return $result;
-    }
-}


### PR DESCRIPTION
This pull request provides the following functionality: 
With this pull request the package creates a Model within the App\Models namespace ( and directory ), or within a custom named models directory when the user executes the following command: `php artisan make:repository Test`

The current default namespace for models in the repositories.php was set to App\Entities.  Also, the path was set to 'app' . DIRECTORY_SEPARATOR . Models.  The RepositoryCreator.php file now reads that.

Also worth mentioning : 
Ideally, I think the generator config should read something like this (it does not read that way currently, but it is a worthy update):
   'generator'=>[
        'basePath'=>app()->path(),
        'rootNamespace'=>'App\\',
        'paths'=>[
            'models'=>'Models',
            'repositories'=>'Repositories\\Eloquent',
            'interfaces'=>'Contracts\\Repositories',
            'transformers'=>'Transformers',
            'presenters'=>'Presenters'
            'validators'   => 'Validators',
            'controllers'  => 'Http/Controllers',
            'provider'     => 'RepositoryServiceProvider',
            'criteria'     => 'Criteria',
        ]
    ]

This pattern I got from this repository:  https://github.com/andersao/l5-repository  BTW, I think they have abandoned this repo as well.  It has a lot of very useful features.