### PR TITLE
Implement .idea directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor
+/.idea
 composer.phar
 composer.lock


### PR DESCRIPTION
Prevent that someone accidently push the Jetbrains .idea folder
also to the repository.