### PR TITLE
Remove trailing comma to fix composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "illuminate/support": "~5",
         "illuminate/database": "~5",
         "illuminate/filesystem": "~5",
-        "illuminate/console": "~5",
+        "illuminate/console": "~5"
     },
     "require-dev": {
         "mockery/mockery": "@stable",


### PR DESCRIPTION
The package cannot be installed atm. Due to a trailing comma n the composer.json file. This PR will fix it.