### PR TITLE
Bump packages and PHP version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "illuminate/support": "~5",
-        "illuminate/database": "~5",
-        "illuminate/filesystem": "~5",
-        "illuminate/console": "~5"
+        "illuminate/support": "^5.4|^6.0",
+        "illuminate/database": "^5.4|^6.0",
+        "illuminate/filesystem": "^5.4|^6.0",
+        "illuminate/console": "^5.4|^6.0"
     },
     "require-dev": {
         "mockery/mockery": "@stable",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.2",
         "illuminate/support": "^5.4|^6.0",
         "illuminate/database": "^5.4|^6.0",
         "illuminate/filesystem": "^5.4|^6.0",


### PR DESCRIPTION
- Updated the required version of PHP to 7.2 and higher because 7.1 is not supported anymore.
- Updated the package dependencies to `^5.4|^6.0`